### PR TITLE
Refactor how `io` and `read` modules work.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ keywords = ["whisper", "graphite", "carbon", "metrics"]
 [dependencies]
 chrono = "0.4.0"
 fs2 = "0.4.2"
-memmap = "0.5.2"
+memmap = "0.6.2"
 memento-core = { path = "core" }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -5,70 +5,27 @@ extern crate test;
 
 use chrono::{TimeZone, Utc};
 use test::Bencher;
-use memento::{FetchRequest, MappedFileStream, MementoFileReader};
+use memento::{FetchRequest, MementoFileReader};
 
 #[bench]
-fn benchmark_mapped_file_stream_with_locking(b: &mut Bencher) {
-    let stream = MappedFileStream::new(true);
-    b.iter(|| stream.run_immutable("tests/upper_01.wsp", |_: &[u8]| Ok(())));
-}
-
-#[bench]
-fn benchmark_mapped_file_stream_no_locking(b: &mut Bencher) {
-    let stream = MappedFileStream::new(false);
-    b.iter(|| stream.run_immutable("tests/upper_01.wsp", |_: &[u8]| Ok(())));
-}
-
-#[bench]
-fn benchmark_memento_file_reader_with_lock_read_header(b: &mut Bencher) {
-    let stream = MappedFileStream::new(true);
-    let reader = MementoFileReader::new(stream);
+fn benchmark_memento_file_reader_read_header(b: &mut Bencher) {
+    let reader = MementoFileReader::new();
     b.iter(|| reader.read_header("tests/upper_01.wsp"));
 }
 
 #[bench]
-fn benchmark_memento_file_reader_with_lock_read_database(b: &mut Bencher) {
-    let stream = MappedFileStream::new(true);
-    let reader = MementoFileReader::new(stream);
+fn benchmark_memento_file_reader_read_database(b: &mut Bencher) {
+    let reader = MementoFileReader::new();
     b.iter(|| reader.read_database("tests/upper_01.wsp"));
 }
 
 #[bench]
-fn benchmark_memento_file_reader_with_lock_read_range(b: &mut Bencher) {
+fn benchmark_memento_file_reader_read_range(b: &mut Bencher) {
     let from = Utc.timestamp(1502089980, 0);
     let until = Utc.timestamp(1502259660, 0);
     let now = Utc.timestamp(1502864800, 0);
     let request = FetchRequest::new(from, until, now);
 
-    let stream = MappedFileStream::new(true);
-    let reader = MementoFileReader::new(stream);
-
-    b.iter(|| reader.read("tests/upper_01.wsp", &request));
-}
-
-#[bench]
-fn benchmark_memento_file_reader_no_lock_read_header(b: &mut Bencher) {
-    let stream = MappedFileStream::new(false);
-    let reader = MementoFileReader::new(stream);
-    b.iter(|| reader.read_header("tests/upper_01.wsp"));
-}
-
-#[bench]
-fn benchmark_memento_file_reader_no_lock_read_database(b: &mut Bencher) {
-    let stream = MappedFileStream::new(false);
-    let reader = MementoFileReader::new(stream);
-    b.iter(|| reader.read_database("tests/upper_01.wsp"));
-}
-
-#[bench]
-fn benchmark_memento_file_reader_no_lock_read_range(b: &mut Bencher) {
-    let from = Utc.timestamp(1502089980, 0);
-    let until = Utc.timestamp(1502259660, 0);
-    let now = Utc.timestamp(1502864800, 0);
-    let request = FetchRequest::new(from, until, now);
-
-    let stream = MappedFileStream::new(false);
-    let reader = MementoFileReader::new(stream);
-
+    let reader = MementoFileReader::new();
     b.iter(|| reader.read("tests/upper_01.wsp", &request));
 }

--- a/core/src/encoder.rs
+++ b/core/src/encoder.rs
@@ -17,7 +17,7 @@ use byteorder::{NetworkEndian, WriteBytesExt};
 use types::{Archive, ArchiveInfo, Data, Header, MementoDatabase, Metadata, Point};
 use errors::MementoResult;
 
-fn encode_metadata<W>(writer: &mut W, meta: &Metadata) -> io::Result<()>
+pub fn memento_encode_metadata<W>(writer: &mut W, meta: &Metadata) -> io::Result<()>
 where
     W: WriteBytesExt,
 {
@@ -27,7 +27,7 @@ where
     writer.write_u32::<NetworkEndian>(meta.archive_count())
 }
 
-fn encode_archive_infos<W>(writer: &mut W, infos: &[ArchiveInfo]) -> io::Result<()>
+pub fn memento_encode_archive_infos<W>(writer: &mut W, infos: &[ArchiveInfo]) -> io::Result<()>
 where
     W: WriteBytesExt,
 {
@@ -40,7 +40,7 @@ where
     Ok(())
 }
 
-fn encode_point<W>(writer: &mut W, point: &Point) -> io::Result<()>
+pub fn memento_encode_point<W>(writer: &mut W, point: &Point) -> io::Result<()>
 where
     W: WriteBytesExt,
 {
@@ -48,7 +48,7 @@ where
     writer.write_f64::<NetworkEndian>(point.value())
 }
 
-fn encode_data<W>(writer: &mut W, data: &Data) -> io::Result<()>
+pub fn memento_encode_data<W>(writer: &mut W, data: &Data) -> io::Result<()>
 where
     W: WriteBytesExt,
 {
@@ -64,7 +64,7 @@ where
     W: WriteBytesExt,
 {
     for point in archive.points() {
-        encode_point(writer, point)?;
+        memento_encode_point(writer, point)?;
     }
 
     Ok(())
@@ -74,8 +74,8 @@ pub fn memento_encode_header<W>(writer: &mut W, header: &Header) -> MementoResul
 where
     W: WriteBytesExt,
 {
-    encode_metadata(writer, header.metadata())?;
-    Ok(encode_archive_infos(writer, header.archive_info())?)
+    memento_encode_metadata(writer, header.metadata())?;
+    Ok(memento_encode_archive_infos(writer, header.archive_info())?)
 }
 
 pub fn memento_encode_database<W>(writer: &mut W, file: &MementoDatabase) -> MementoResult<()>
@@ -83,7 +83,7 @@ where
     W: WriteBytesExt,
 {
     memento_encode_header(writer, file.header())?;
-    Ok(encode_data(writer, file.data())?)
+    Ok(memento_encode_data(writer, file.data())?)
 }
 
 #[cfg(test)]
@@ -91,11 +91,12 @@ mod tests {
     use types::{AggregationType, Archive, ArchiveInfo, Data, Header, MementoDatabase, Metadata,
                 Point};
 
-    use super::{encode_archive_infos, encode_data, encode_metadata, encode_point,
-                memento_encode_archive, memento_encode_database, memento_encode_header};
+    use super::{memento_encode_archive_infos, memento_encode_data, memento_encode_metadata,
+                memento_encode_point, memento_encode_archive, memento_encode_database,
+                memento_encode_header};
 
     #[test]
-    fn test_encode_metadata() {
+    fn test_memento_encode_metadata() {
         let metadata = Metadata::new(AggregationType::Max, 31536000, 0.5, 5);
 
         // Python: struct.pack('>LLfL', 4, 31536000, 0.5, 5).hex()
@@ -108,13 +109,13 @@ mod tests {
         ];
 
         let mut buf = vec![];
-        encode_metadata(&mut buf, &metadata).unwrap();
+        memento_encode_metadata(&mut buf, &metadata).unwrap();
 
         assert_eq!(&expected, &buf);
     }
 
     #[test]
-    fn test_encode_archive_infos() {
+    fn test_memento_encode_archive_infos() {
         let info = ArchiveInfo::new(76, 10, 8640);
 
         // Python: struct.pack('>LLL', 76, 10, 8640).hex()
@@ -126,13 +127,13 @@ mod tests {
         ];
 
         let mut buf = vec![];
-        encode_archive_infos(&mut buf, &vec![info]).unwrap();
+        memento_encode_archive_infos(&mut buf, &vec![info]).unwrap();
 
         assert_eq!(&expected, &buf);
     }
 
     #[test]
-    fn test_encode_point() {
+    fn test_memento_encode_point() {
         let point = Point::new(1511396041, 42.0);
 
         // Python: struct.pack('>Ld', 1511396041, 42.0).hex()
@@ -143,13 +144,13 @@ mod tests {
         ];
 
         let mut buf = vec![];
-        encode_point(&mut buf, &point).unwrap();
+        memento_encode_point(&mut buf, &point).unwrap();
 
         assert_eq!(&expected, &buf);
     }
 
     #[test]
-    fn test_encode_data() {
+    fn test_memento_encode_data() {
         let point1 = Point::new(1511396041, 42.0);
         let point2 = Point::new(1511396051, 42.0);
         let archive = Archive::new(vec![point1, point2]);
@@ -168,7 +169,7 @@ mod tests {
         ];
 
         let mut buf = vec![];
-        encode_data(&mut buf, &data).unwrap();
+        memento_encode_data(&mut buf, &data).unwrap();
 
         assert_eq!(&expected, &buf);
     }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -14,7 +14,7 @@ use nom::{IResult, be_f32, be_f64, be_u32};
 
 use types::{AggregationType, Archive, ArchiveInfo, Data, Header, MementoDatabase, Metadata, Point};
 
-named!(parse_aggregation_type<&[u8], AggregationType>,
+named!(pub memento_parse_aggregation_type<&[u8], AggregationType>,
        switch!(be_u32,
                1 => value!(AggregationType::Average) |
                2 => value!(AggregationType::Sum)     |
@@ -27,7 +27,7 @@ named!(parse_aggregation_type<&[u8], AggregationType>,
        )
 );
 
-named!(parse_archive_info<&[u8], ArchiveInfo>,
+named!(pub memento_parse_archive_info<&[u8], ArchiveInfo>,
        do_parse!(
            offset:         be_u32 >>
            secs_per_point: be_u32 >>
@@ -40,18 +40,18 @@ named!(parse_archive_info<&[u8], ArchiveInfo>,
        )
 );
 
-fn parse_archive_infos<'a, 'b>(
+pub fn memento_parse_archive_infos<'a, 'b>(
     input: &'a [u8],
     metadata: &'b Metadata,
 ) -> IResult<&'a [u8], Vec<ArchiveInfo>> {
     let (remaining, infos) = try_parse!(
         input,
-        count!(parse_archive_info, metadata.archive_count() as usize)
+        count!(memento_parse_archive_info, metadata.archive_count() as usize)
     );
     IResult::Done(remaining, infos)
 }
 
-fn parse_data<'a, 'b>(input: &'a [u8], infos: &'b [ArchiveInfo]) -> IResult<&'a [u8], Data> {
+pub fn memento_parse_data<'a, 'b>(input: &'a [u8], infos: &'b [ArchiveInfo]) -> IResult<&'a [u8], Data> {
     let mut archives = Vec::with_capacity(infos.len());
     let mut to_parse = input;
 
@@ -64,12 +64,12 @@ fn parse_data<'a, 'b>(input: &'a [u8], infos: &'b [ArchiveInfo]) -> IResult<&'a 
     IResult::Done(to_parse, Data::new(archives))
 }
 
-named!(parse_metadata<&[u8], Metadata>,
+named!(pub memento_parse_metadata<&[u8], Metadata>,
        do_parse!(
-           aggregation:    parse_aggregation_type >>
-           max_retention:  be_u32                 >>
-           x_files_factor: be_f32                 >>
-           archive_count:  be_u32                 >>
+           aggregation:    memento_parse_aggregation_type >>
+           max_retention:  be_u32                         >>
+           x_files_factor: be_f32                         >>
+           archive_count:  be_u32                         >>
            (Metadata::new(
                aggregation,
                max_retention,
@@ -79,7 +79,7 @@ named!(parse_metadata<&[u8], Metadata>,
        )
 );
 
-named!(parse_point<&[u8], Point>,
+named!(pub memento_parse_point<&[u8], Point>,
        do_parse!(
            timestamp: be_u32 >>
            value:     be_f64 >>
@@ -89,8 +89,8 @@ named!(parse_point<&[u8], Point>,
 
 named!(pub memento_parse_header<&[u8], Header>,
        do_parse!(
-           metadata: parse_metadata                         >>
-           archives: apply!(parse_archive_infos, &metadata) >>
+           metadata: memento_parse_metadata                         >>
+           archives: apply!(memento_parse_archive_infos, &metadata) >>
            (Header::new(metadata, archives))
        )
 );
@@ -99,15 +99,17 @@ pub fn memento_parse_archive<'a, 'b>(
     input: &'a [u8],
     info: &'b ArchiveInfo,
 ) -> IResult<&'a [u8], Archive> {
-    let (remaining, points) = try_parse!(input, count!(parse_point, info.num_points() as usize));
+    let (remaining, points) = try_parse!(input, count!(
+        memento_parse_point, info.num_points() as usize
+    ));
 
     IResult::Done(remaining, Archive::new(points))
 }
 
 named!(pub memento_parse_database<&[u8], MementoDatabase>,
        do_parse!(
-           header: memento_parse_header                      >>
-           data:   apply!(parse_data, header.archive_info()) >>
+           header: memento_parse_header                              >>
+           data:   apply!(memento_parse_data, header.archive_info()) >>
            (MementoDatabase::new(header, data))
        )
 );
@@ -118,19 +120,20 @@ mod tests {
                 Point};
 
     use super::{memento_parse_archive, memento_parse_database, memento_parse_header,
-                parse_aggregation_type, parse_archive_info, parse_archive_infos, parse_data,
-                parse_metadata, parse_point};
+                memento_parse_aggregation_type, memento_parse_archive_info,
+                memento_parse_archive_infos, memento_parse_data, memento_parse_metadata,
+                memento_parse_point};
 
     #[test]
-    fn test_parse_aggregation_type() {
+    fn test_memento_parse_aggregation_type() {
         // Python: struct.pack('>L', 4).hex()
         let bytes = vec![0x00, 0x00, 0x00, 0x04];
-        let res = parse_aggregation_type(&bytes).unwrap().1;
+        let res = memento_parse_aggregation_type(&bytes).unwrap().1;
         assert_eq!(AggregationType::Max, res);
     }
 
     #[test]
-    fn test_parse_archive_info() {
+    fn test_memento_parse_archive_info() {
         let expected = ArchiveInfo::new(76, 10, 8640);
 
         // Python: struct.pack('>LLL', 76, 10, 8640).hex()
@@ -141,12 +144,12 @@ mod tests {
             0x00, 0x00, 0x21, 0xc0
         ];
 
-        let res = parse_archive_info(&bytes).unwrap().1;
+        let res = memento_parse_archive_info(&bytes).unwrap().1;
         assert_eq!(expected, res);
     }
 
     #[test]
-    fn test_parse_archive_infos() {
+    fn test_memento_parse_archive_infos() {
         let expected = ArchiveInfo::new(28, 10, 8640);
         let metadata = Metadata::new(AggregationType::Average, 86400, 0.5, 1);
 
@@ -159,12 +162,12 @@ mod tests {
 
         ];
 
-        let res = parse_archive_infos(&bytes, &metadata).unwrap().1;
+        let res = memento_parse_archive_infos(&bytes, &metadata).unwrap().1;
         assert_eq!(vec![expected], res);
     }
 
     #[test]
-    fn test_parse_data() {
+    fn test_memento_parse_data() {
         let point1 = Point::new(1511396041, 42.0);
         let point2 = Point::new(1511396051, 42.0);
         let archive = Archive::new(vec![point1, point2]);
@@ -184,12 +187,12 @@ mod tests {
             0x40, 0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
         ];
 
-        let res = parse_data(&bytes, &vec![info]).unwrap().1;
+        let res = memento_parse_data(&bytes, &vec![info]).unwrap().1;
         assert_eq!(expected, res);
     }
 
     #[test]
-    fn test_parse_metadata() {
+    fn test_memento_parse_metadata() {
         let expected = Metadata::new(AggregationType::Sum, 86400, 0.5, 1);
 
         // Python: struct.pack('>LLfL', 2, 86400, 0.5, 1).hex()
@@ -201,12 +204,12 @@ mod tests {
             0x00, 0x00, 0x00, 0x01
         ];
 
-        let res = parse_metadata(&bytes).unwrap().1;
+        let res = memento_parse_metadata(&bytes).unwrap().1;
         assert_eq!(expected, res);
     }
 
     #[test]
-    fn test_parse_point() {
+    fn test_memento_parse_point() {
         let expected = Point::new(1511396041, 42.0);
 
         // Python: struct.pack('>Ld', 1511396041, 42.0).hex()
@@ -216,7 +219,7 @@ mod tests {
             0x40, 0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
-        let res = parse_point(&bytes).unwrap().1;
+        let res = memento_parse_point(&bytes).unwrap().1;
         assert_eq!(expected, res);
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,118 +8,407 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Functions to read and write parts of the Whisper format to disk
+//! Functions to read parts of the Whisper format from disk
 
-use std::io;
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+use std::fmt::{self, Debug};
 use std::fs::File;
-use std::path::Path;
 
-use fs2::FileExt;
-use memmap::{Mmap, Protection};
+use memento_core::errors::{MementoError, MementoResult};
 
-use memento_core::errors::MementoResult;
+// Default buffer size used by `SliceReaderDirect`. Big enough to
+// be used for an entire typical Whisper database header (metadata
+// + eight or fewer archive info sections).
+const DEFAULT_DIRECT_IO_BUFFER: usize = 128;
 
-// TODO: File locking is at the process level. Do we need to also
-// use a mutex to make sure only a single thread tries to access
-// a particular file at a time? Does this fall outside the scope
-// of this library? Maybe just have a big warning?
+/// Trait to combine `Seek` and `Read` so that we can use a `Box` to hold
+/// a single object that implements both. This wouldn't be possible otherwise
+/// since they are not 'auto traits'.
+pub trait SeekRead: Seek + Read {}
 
-/// Lock a file on creation and unlock it on destruction.
+impl SeekRead for File {}
+
+impl<'a> SeekRead for &'a File {}
+
+impl<T> SeekRead for Cursor<T> where T: AsRef<[u8]> {}
+
+/// Trait for consuming bytes from some type of underlying file as a range of
+/// bytes.
 ///
-/// Locking can be enabled or disabled via the `enabled` flag when
-/// creating this locker. All errors unlocking a file in the
-/// destructor are ignored.
-struct FileLocker<'a> {
-    enabled: bool,
-    file: &'a File,
-}
-
-impl<'a> FileLocker<'a> {
-    /// Obtain a read-only lock on the given file (if `enabled` is
-    /// `true`), returning an error if the lock could not be obtained.
-    fn lock_shared(enabled: bool, file: &'a File) -> io::Result<FileLocker<'a>> {
-        if enabled {
-            file.lock_shared()?;
-        }
-
-        Ok(FileLocker {
-            enabled: enabled,
-            file: file,
-        })
-    }
-}
-
-impl<'a> Drop for FileLocker<'a> {
-    fn drop(&mut self) {
-        if !self.enabled {
-            return;
-        }
-
-        // Try to unlock but if it fails there's really nothing to do about
-        // it. Probably don't want to be logging from a library and we can't
-        // panic or return an Err from a destructor.
-        match self.file.unlock() {
-            _ => (),
-        };
-    }
-}
-
-///
-///
-///
-///
-///
-#[derive(Debug, Clone)]
-pub struct MappedFileStream {
-    locking: bool,
-}
-
-impl MappedFileStream {
-    pub fn new(locking: bool) -> Self {
-        MappedFileStream { locking: locking }
-    }
-
-    pub fn run_immutable<P, F, T>(&self, path: P, consumer: F) -> MementoResult<T>
+/// The trait is meant to abstract the differences between direct file I/O and
+/// memory mapped files, allowing callers to choose the implementation with the
+/// best performance for their use case.
+pub trait SliceReader {
+    fn consume_all<F, T>(&mut self, consumer: F) -> MementoResult<T>
     where
-        P: AsRef<Path>,
+        F: Fn(&[u8]) -> MementoResult<T>;
+
+    fn consume_from<F, T>(&mut self, offset: u64, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>;
+
+    fn consume<F, T>(&mut self, offset: u64, len: u64, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>;
+}
+
+/// Implementation of a `SliceReader` that expects to operate on a memory mapped
+/// file (something that can be represented as a `&[u8]`.
+///
+/// Offsets are always computed relative to the start of the mapping.
+///
+/// # Errors
+///
+/// Out of bounds or invalid reads will result in an error being returned.
+/// Examples of out of bounds or invalid reads include an offset that is
+/// larger than the mapping, or a length that results in a read extending
+/// beyond the end of the mapping.
+pub struct SliceReaderMapped {
+    map: Box<AsRef<[u8]>>,
+}
+
+impl SliceReaderMapped {
+    /// Create a new `SliceReaderMapped` instance that consumes bytes from the
+    /// provided byte range (typically a memory mapped file).
+    pub fn new<M>(map: M) -> Self where M: AsRef<[u8]> + 'static {
+        SliceReaderMapped { map: Box::new(map) }
+    }
+
+    fn read_range<F, T>(&mut self, offset: u64, len: Option<u64>, consumer: F) -> MementoResult<T>
+    where
         F: Fn(&[u8]) -> MementoResult<T>,
     {
-        let file = File::open(path)?;
-        // Not used, we just need it to unlock the file in its destructor
-        let _locker = FileLocker::lock_shared(self.locking, &file)?;
+        let start = offset as usize;
+        let max = self.map.as_ref().as_ref().len();
+        let end = len.map(|n| (offset + n) as usize).unwrap_or(max);
 
-        let mmap = Mmap::open(&file, Protection::Read)?;
-        let res = {
-            // Unsafe is OK here since we've obtained a shared (read) lock
-            let bytes = unsafe { mmap.as_slice() };
-            consumer(bytes)?
-        };
+        if start >= max {
+            return Err(MementoError::from(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("read range start too large. start {}, max {}", start, max)
+            )))
+        }
 
-        Ok(res)
+        if end > max {
+            return Err(MementoError::from(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("read range end too large. end {}, max {}", end, max)
+            )))
+        }
+
+        consumer(&self.map.as_ref().as_ref()[start..end])
     }
 }
 
-impl Default for MappedFileStream {
-    fn default() -> Self {
-        Self::new(true)
+impl SliceReader for SliceReaderMapped {
+    fn consume_all<F, T>(&mut self, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>,
+    {
+        self.read_range(0, None, consumer)
+    }
+
+    fn consume_from<F, T>(&mut self, offset: u64, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>,
+    {
+        self.read_range(offset, None, consumer)
+    }
+
+    fn consume<F, T>(&mut self, offset: u64, len: u64, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>,
+    {
+        self.read_range(offset, Some(len), consumer)
+    }
+}
+
+impl Debug for SliceReaderMapped {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "SliceReaderMapped {{ map: &[...] }}")
+    }
+}
+
+/// Implementation of a `SliceReader` that expects to operate on a `SeekRead`
+/// implementation that refers to a file that we are doing I/O on directly.
+///
+/// Offsets are always computed relative to the start of the file. Any seeks
+/// performed are always absolute and relative to the start of the file. The
+/// cursor position is not reset after the read is performed.
+///
+/// The instance maintains a heap allocated buffer that is used for each read,
+/// and grown to the needed capacity for the read. The buffer never shrinks in
+/// capacity.
+///
+/// # Errors
+///
+/// Invalid reads will result in an error being returned. Examples of invalid
+/// reads include an offset that is larger than the underlying file, or a length
+/// that results in a read extending beyond the end of the file.
+pub struct SliceReaderDirect {
+    buffer: Vec<u8>,
+    reader: Box<SeekRead>,
+}
+
+impl SliceReaderDirect {
+    /// Create a new `SliceReaderDirect` instance that consumes bytes from the
+    /// provided reader. The buffer used for reads is allocated upon creation
+    /// with a default size appropriate for reading a Whisper file header.
+    pub fn new<R>(reader: R) -> Self where R: SeekRead + 'static {
+        SliceReaderDirect {
+            buffer: Vec::with_capacity(DEFAULT_DIRECT_IO_BUFFER),
+            reader: Box::new(reader)
+        }
+    }
+
+    fn read_range<F, T>(&mut self, offset: u64, len: Option<u64>, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>,
+    {
+        let reader = &mut self.reader;
+        // Note that we have no way to know if the seek went beyond the end
+        // of the reader. Since this is allowed by the trait and the result of
+        // it is implementation defined, we don't bother trying to prevent it
+        // here. Instead, we'll just return an error if we can't read anything.
+        reader.seek(SeekFrom::Start(offset))?;
+        self.buffer.clear();
+
+        // If we have a specific number of bytes to read. Ensure that our
+        // buffer is sized correctly and then limit the number of bytes we'll
+        // read from our reader instance. Otherwise just read until EOF
+        let bytes_read = if let Some(v) = len {
+            let needed = v as i64 - self.buffer.capacity() as i64;
+            if needed > 0 {
+                self.buffer.reserve_exact(needed as usize);
+            }
+
+            reader.take(v).read_to_end(&mut self.buffer)?
+        } else {
+            reader.read_to_end(&mut self.buffer)?
+        };
+
+        // If we weren't able to read anything from our reader, we may have
+        // ended up seeking beyond the end of the file. Return an error here
+        // since this likely indicates a problem and trying to consume 0 bytes
+        // isn't very useful.
+        if bytes_read == 0 {
+            return Err(MementoError::from(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("no bytes to read. offset {}", offset)
+            )))
+        }
+
+        // If there was an explicit number of bytes we were supposed to read
+        // and it doesn't match the number actually read, return an error since
+        // this likely indicates a corrupt file or other problem.
+        if let Some(v) = len {
+            if (bytes_read as u64) < v {
+                return Err(MementoError::from(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("short read. wanted {}, read {}", v, bytes_read)
+                )))
+            }
+        }
+
+        consumer(&self.buffer)
+    }
+}
+
+impl SliceReader for SliceReaderDirect {
+    fn consume_all<F, T>(&mut self, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>,
+    {
+        self.read_range(0, None, consumer)
+    }
+
+    fn consume_from<F, T>(&mut self, offset: u64, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>,
+    {
+        self.read_range(offset, None, consumer)
+    }
+
+    fn consume<F, T>(&mut self, offset: u64, len: u64, consumer: F) -> MementoResult<T>
+    where
+        F: Fn(&[u8]) -> MementoResult<T>,
+    {
+        self.read_range(offset, Some(len), consumer)
+    }
+}
+
+impl Debug for SliceReaderDirect {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "SliceReaderDirect {{ buffer: {:?}, reader: {{...}} }}", self.buffer)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::MappedFileStream;
+    use std::io::{Cursor};
+    use memento_core::errors::ErrorKind;
+    use super::{SliceReader, SliceReaderMapped, SliceReaderDirect};
+
+    fn get_bytes() -> Vec<u8> {
+        vec![0xDE, 0xAD, 0xBE, 0xEF]
+    }
 
     #[test]
-    fn test_mapped_file_stream_immutable() {
-        let expected: [u8; 1024] = [0; 1024];
-        let expected_ref = &expected as &[u8];
+    fn test_slice_reader_mapped_consume_all_success() {
+        let map = get_bytes();
+        let expected = map.clone();
 
-        let mapper = MappedFileStream::default();
-        let _ = mapper
-            .run_immutable("tests/zero_file.bin", |bytes| {
-                assert_eq!(expected_ref, bytes);
-                Ok(0)
-            })
-            .unwrap();
+        let mut slice_reader = SliceReaderMapped::new(map);
+        let res = slice_reader.consume_all(|v| {
+            Ok(Vec::from(v))
+        });
+
+        assert_eq!(expected, res.unwrap());
+    }
+
+    #[test]
+    fn test_slice_reader_mapped_consume_from_success() {
+        let map = get_bytes();
+        let expected = map.clone();
+
+        let mut slice_reader = SliceReaderMapped::new(map);
+        let res = slice_reader.consume_from(0, |v| {
+            Ok(Vec::from(v))
+        });
+
+        assert_eq!(expected, res.unwrap());
+    }
+
+    #[test]
+    fn test_slice_reader_mapped_consume_from_bad_offset() {
+        let map = get_bytes();
+        let mut slice_reader = SliceReaderMapped::new(map);
+        let res = slice_reader.consume_from(4, |v| {
+            Ok(Vec::from(v))
+        });
+
+        let err = res.unwrap_err();
+        assert_eq!(ErrorKind::IoError, err.kind());
+    }
+
+    #[test]
+    fn test_slice_reader_mapped_consume_success() {
+        let map = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let expected = map.clone();
+
+        let mut slice_reader = SliceReaderMapped::new(map);
+        let res = slice_reader.consume(0, 4, |v| {
+            Ok(Vec::from(v))
+        });
+
+        assert_eq!(expected, res.unwrap());
+    }
+
+    #[test]
+    fn test_slice_reader_mapping_consume_bad_offset() {
+        let map = get_bytes();
+        let mut slice_reader = SliceReaderMapped::new(map);
+        let res = slice_reader.consume(4, 4, |v| {
+            Ok(Vec::from(v))
+        });
+
+        let err = res.unwrap_err();
+        assert_eq!(ErrorKind::IoError, err.kind());
+    }
+
+    #[test]
+    fn test_slice_reader_mapping_consume_bad_length() {
+        let map = get_bytes();
+        let mut slice_reader = SliceReaderMapped::new(map);
+        let res = slice_reader.consume(2, 4, |v| {
+            Ok(Vec::from(v))
+        });
+
+        let err = res.unwrap_err();
+        assert_eq!(ErrorKind::IoError, err.kind());
+    }
+
+    #[test]
+    fn test_slice_reader_direct_consume_all_success() {
+        let bytes = get_bytes();
+        let expected = bytes.clone();
+        let reader = Cursor::new(bytes);
+
+        let mut slice_reader = SliceReaderDirect::new(reader);
+        let res = slice_reader.consume_all(|v| {
+            Ok(Vec::from(v))
+        });
+
+        assert_eq!(expected, res.unwrap());
+    }
+
+    #[test]
+    fn test_slice_reader_direct_consume_from_success() {
+        let bytes = get_bytes();
+        let expected = bytes.clone();
+        let reader = Cursor::new(bytes);
+
+        let mut slice_reader = SliceReaderDirect::new(reader);
+        let res = slice_reader.consume_from(0, |v| {
+            Ok(Vec::from(v))
+        });
+
+        assert_eq!(expected, res.unwrap());
+    }
+
+    #[test]
+    fn test_slice_reader_direct_consume_from_bad_offset() {
+        let bytes = get_bytes();
+        let reader = Cursor::new(bytes);
+
+        let mut slice_reader = SliceReaderDirect::new(reader);
+        let res = slice_reader.consume_from(4, |v| {
+            Ok(Vec::from(v))
+        });
+
+        let err = res.unwrap_err();
+        assert_eq!(ErrorKind::IoError, err.kind());
+    }
+
+    #[test]
+    fn test_slice_reader_direct_consume_success() {
+        let bytes = get_bytes();
+        let expected = bytes.clone();
+        let reader = Cursor::new(bytes);
+
+        let mut slice_reader = SliceReaderDirect::new(reader);
+        let res = slice_reader.consume(0, 4, |v| {
+            Ok(Vec::from(v))
+        });
+
+        assert_eq!(expected, res.unwrap());
+    }
+
+    #[test]
+    fn test_slice_reader_direct_consume_bad_offset() {
+        let bytes = get_bytes();
+        let reader = Cursor::new(bytes);
+
+        let mut slice_reader = SliceReaderDirect::new(reader);
+        let res = slice_reader.consume(4, 4, |v| {
+            Ok(Vec::from(v))
+        });
+
+        let err = res.unwrap_err();
+        assert_eq!(ErrorKind::IoError, err.kind());
+    }
+
+    #[test]
+    fn test_slice_reader_direct_consume_bad_length() {
+        let bytes = get_bytes();
+        let reader = Cursor::new(bytes);
+
+        let mut slice_reader = SliceReaderDirect::new(reader);
+        let res = slice_reader.consume(2, 4, |v| {
+            Ok(Vec::from(v))
+        });
+
+        let err = res.unwrap_err();
+        assert_eq!(ErrorKind::IoError, err.kind());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,5 @@ mod io;
 
 pub use memento_core::types;
 pub use memento_core::errors;
-pub use read::{FetchRequest, MementoFileReader};
-pub use io::MappedFileStream;
+pub use io::{SeekRead, SliceReader, SliceReaderDirect, SliceReaderMapped};
+pub use read::{DefaultMementoParser, FetchRequest, FetchResponse, MementoParser, MementoFileReader};

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,13 +1,41 @@
+extern crate chrono;
 extern crate memento;
 
-#[test]
-fn test_whisper_reader_read_with_high_precison_archive() {}
+use chrono::{TimeZone, Utc};
+use memento::{MementoFileReader, FetchRequest};
+use memento::types::AggregationType;
 
 #[test]
-fn test_whisper_reader_read_with_lower_precision_archive() {}
+fn test_memento_file_reader_read_header() {
+    let reader = MementoFileReader::new();
+    let header = reader.read_header("tests/upper_01.wsp").unwrap();
+
+    assert_eq!(AggregationType::Max, header.metadata().aggregation());
+    assert_eq!(5, header.metadata().archive_count());
+}
 
 #[test]
-fn test_whisper_reader_read_with_mixed_timestamp_data_in_archive() {}
+fn test_memento_file_reader_read_database() {
+    let reader = MementoFileReader::new();
+    let database = reader.read_database("tests/upper_01.wsp").unwrap();
+    let header = database.header();
+
+    assert_eq!(AggregationType::Max, header.metadata().aggregation());
+    assert_eq!(5, database.data().archives().len());
+}
 
 #[test]
-fn test_whisper_reader_read_valid_header_missing_data() {}
+fn test_memento_file_reader_read() {
+    let from = Utc.timestamp(1502089980, 0);
+    let until = Utc.timestamp(1502259660, 0);
+    let now = Utc.timestamp(1502864800, 0);
+    let request = FetchRequest::new(from, until, now);
+
+    let reader = MementoFileReader::new();
+    let response = reader.read("tests/upper_01.wsp", &request).unwrap();
+    let info = response.archive();
+    let points = response.points();
+
+    assert_eq!(300, info.seconds_per_point());
+    assert_eq!(566, points.len());
+}


### PR DESCRIPTION
Parsing is now decoupled from the method used to access the file. This
is abstracted via the `SliceReader` trait. There is a direct I/O impl as
well as a mmap impl.

Current limitations:
* Each `read_X` method is hardcoded to use one impl (direct or mapped)
  based on the type of read being done.
* No locking of any kind is done on the files or in memory.